### PR TITLE
chore: cabal-fmt and update authors and maintainers

### DIFF
--- a/hattier.cabal
+++ b/hattier.cabal
@@ -1,33 +1,46 @@
-cabal-version:      3.0
-name:               hattier
-version:            0.1.0.0
-synopsis:           Cute Haskell formatter
-license:            BSD-3-Clause
-license-file:       LICENSE
-author:             vicgeentor
-maintainer:         hattier@vicgeentor.nl
-category:           Development
-build-type:         Simple
+cabal-version: 3.0
+name:          hattier
+version:       0.1.0.0
+synopsis:      Cute Haskell formatter
+license:       BSD-3-Clause
+license-file:  LICENSE
+author:
+  , "Fyor Lambermont" <f.t.lambermont@students.uu.nl>
+  , "Vic ten Bokum" <v.a.a.tenbokum@students.uu.nl>
+  , "Lumen de Vries" <l.devries13@students.uu.nl>
+  , "Emilia P. Stoyanova" <e.p.stoyanova@students.uu.nl>
+
+maintainer:
+  , "Fyor Lambermont" <f.t.lambermont@students.uu.nl>
+  , "Vic ten Bokum" <v.a.a.tenbokum@students.uu.nl>
+  , "Lumen de Vries" <l.devries13@students.uu.nl>
+  , "Emilia P. Stoyanova" <e.p.stoyanova@students.uu.nl>
+
+category:      Development
+build-type:    Simple
 
 common warnings
-    ghc-options: -Wall
+  ghc-options: -Wall
 
 executable hattier
-    import:           warnings
-    main-is:          Main.hs
-    -- other-modules:
-    -- other-extensions:
-    build-depends:    base ^>=4.20.2.0,
-    hs-source-dirs:   src
-    default-language: Haskell2010
+  import:           warnings
+  main-is:          Main.hs
+
+  -- other-modules:
+  -- other-extensions:
+  build-depends:    base
+  hs-source-dirs:   src
+  default-language: Haskell2010
 
 test-suite tests
-    import:           warnings
-    type:             exitcode-stdio-1.0
-    main-is:          Main.hs
-    build-depends:    base ^>=4.20.2.0,
-                      tasty ^>=1.5.3,
-                      tasty-quickcheck ^>=0.11.1,
-                      QuickCheck ^>=2.17.1.0,
-    hs-source-dirs:   test
-    default-language: Haskell2010
+  import:           warnings
+  type:             exitcode-stdio-1.0
+  main-is:          Main.hs
+  build-depends:
+    , base
+    , QuickCheck        ^>=2.17.1.0
+    , tasty             ^>=1.5.3
+    , tasty-quickcheck  ^>=0.11.1
+
+  hs-source-dirs:   test
+  default-language: Haskell2010


### PR DESCRIPTION
Restricting base's major version (the A.B. part) is silly for the moment imho.
I don't think for the time being our library will require any brand-new functions from base.

Ideally we would just set it to [LTS GHC's](https://www.haskell.org/ghc/blog/20250702-ghc-release-schedules.html) base version, but that does not exist yet.
Alternatively we can use `ghcup`'s recommended base (4.18.3.0).
Either way if we're locking base, it's actually probably best to lock ghc using `with-compiler: <A.B.C>`

For the time being, I'll continue to use Arch's `ghc` (9.6.6) as that hasn't caused me any problems.