### PR TITLE
refactor: move ast into our global Reader and remove `current*` out of our state

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,12 +17,13 @@ main = do
   --- Read source files to format ---
   -----------------------------------
   let sourceFile = undefined
-  let ast =
+      source =
         case parseTextToAST sourceFile defaultParserOpts of
           Left e -> throw e
           Right ast' -> ast'
+      env = Env source config
   --------------
   --- Format ---
   --------------
-  let _ = execHattier (hattier ast) config initialState
+  let _ = execHattier hattier env initialState
   return ()

--- a/src/Hattier.hs
+++ b/src/Hattier.hs
@@ -1,7 +1,7 @@
 module Hattier where
 
 import Hattier.Format (fmt)
-import Hattier.Types (Hattier, HattierModule)
+import Hattier.Types (Hattier)
 
-hattier :: HattierModule -> Hattier
+hattier :: Hattier
 hattier = fmt

--- a/src/Hattier/Format.hs
+++ b/src/Hattier/Format.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module Hattier.Format
   ( fmt
   ) where
@@ -7,8 +5,8 @@ module Hattier.Format
 import Hattier.Printer.Core
 import Hattier.Types
 
-fmt :: HattierModule -> Hattier
-fmt ast = do
-  printModHeader ast
-  printModImports ast
-  printModDecls ast
+fmt :: Hattier
+fmt = do
+  printModHeader
+  printModImports
+  printModDecls

--- a/src/Hattier/Printer/Combinators.hs
+++ b/src/Hattier/Printer/Combinators.hs
@@ -2,37 +2,13 @@ module Hattier.Printer.Combinators where
 
 import Control.Monad.RWS
 import Data.Text (Text)
-import qualified Data.Text as T
 import qualified Data.Text.Lazy.Builder as B
 import Hattier.Types
 
 append :: Text -> Hattier
 append "" = pure ()
 append txt = do
-  s <- get
-  let ind = currentIndent s
-      col = currentColumn s
-      spaces =
-        if col == 0
-          then T.replicate ind " "
-          else mempty
-      indentedTxt = spaces <> txt
-  modify' $ \s' ->
-    s'
-      { builder = builder s <> B.fromText indentedTxt
-      , currentColumn = currentColumn s + T.length indentedTxt
-      }
+  modify' $ \s -> s {builder = builder s <> B.fromText txt}
 
 newline :: Hattier
-newline = do
-  modify' $ \s -> s {builder = builder s <> "\n", currentColumn = 0}
-
-incrIndent :: Hattier
-incrIndent = do
-  width <- asks indentWidth
-  modify' $ \s -> s {currentIndent = currentIndent s + width}
-
-decrIndent :: Hattier
-decrIndent = do
-  width <- asks indentWidth
-  modify' $ \s -> s {currentIndent = max 0 (currentIndent s - width)}
+newline = append "\n"

--- a/src/Hattier/Printer/Core.hs
+++ b/src/Hattier/Printer/Core.hs
@@ -2,6 +2,7 @@
 
 module Hattier.Printer.Core where
 
+import Control.Monad.RWS
 import qualified Data.Text as T
 import GHC.Hs
 import GHC.Types.SrcLoc
@@ -9,15 +10,16 @@ import GHC.Utils.Outputable (ppr, showSDocUnsafe)
 import Hattier.Printer.Combinators
 import Hattier.Types
 
-printModHeader :: HattierModule -> Hattier
-printModHeader HsModule {..} = do
+printModHeader :: Hattier
+printModHeader = do
+  source <- asks ast
   append "module "
   -- parse the module name
-  case hsmodName of
+  case hsmodName source of
     Nothing -> pure ()
     Just (L _ n) -> printModName n
   -- parse module exports
-  case hsmodExports of
+  case hsmodExports source of
     Nothing -> pure ()
     Just exps -> printModExports exps
   append " where"
@@ -31,20 +33,23 @@ printModName name = append (T.pack $ moduleNameString name)
 printModExports :: XRec GhcPs [LIE GhcPs] -> Hattier
 printModExports _ = pure ()
 
-printModImports :: HattierModule -> Hattier
-printModImports HsModule {..} = mapM_ printImport hsmodImports
+printModImports :: Hattier
+printModImports = do
+  source <- asks ast
+  mapM_ printImport (hsmodImports source)
 
 -- TODO: append an import statement (including qualified, as, etc.)
 printImport :: LImportDecl GhcPs -> Hattier
 printImport (L _ ImportDecl {}) = pure ()
 
-printModDecls :: HattierModule -> Hattier
-printModDecls HsModule {..}
+printModDecls :: Hattier
+printModDecls
   -- splitting up these cases enables us to only put
   -- newlines in between declarations and not after the
   -- final one.
- =
-  case hsmodDecls of
+ = do
+  source <- asks ast
+  case hsmodDecls source of
     [] -> pure ()
     d:ds -> do
       printDecl d

--- a/src/Hattier/Types.hs
+++ b/src/Hattier/Types.hs
@@ -5,7 +5,7 @@ import Data.Text.Lazy (Text)
 import Data.Text.Lazy.Builder (Builder, toLazyText)
 import GHC.Hs (GhcPs, HsModule)
 
-type Hattier = RWS Config Log FormatterState ()
+type Hattier = RWS Env Log FormatterState ()
 
 type Log = [Text]
 
@@ -16,20 +16,22 @@ data Config = Config
   , maxLineLength :: Int
   }
 
+data Env = Env
+  { ast :: HattierModule
+  , cfg :: Config
+  }
+
 data FormatterState = FormatterState
-  { currentIndent :: !Int
-  , currentColumn :: !Int
-  , builder :: Builder -- The rendered source code so far
+  { builder :: Builder -- The rendered source code so far
   }
 
 defaultConfig :: Config
 defaultConfig = Config {indentWidth = 2, maxLineLength = 80}
 
 initialState :: FormatterState
-initialState =
-  FormatterState {currentIndent = 0, currentColumn = 0, builder = mempty}
+initialState = FormatterState {builder = mempty}
 
-execHattier :: Hattier -> Config -> FormatterState -> (Text, Log)
-execHattier hat cfg st =
-  let (finalState, logs) = execRWS hat cfg st
+execHattier :: Hattier -> Env -> FormatterState -> (Text, Log)
+execHattier hat env st =
+  let (finalState, logs) = execRWS hat env st
    in (toLazyText (builder finalState), logs)

--- a/test/Unit/Format.hs
+++ b/test/Unit/Format.hs
@@ -14,14 +14,13 @@ tests =
   testGroup
     "Format tests"
     [ testCase
-        "formatting with the GHC pretty printer works properly"
-        testFmtWithBuiltinGHC
+        "formatting an extremely simple module works properly"
+        fmtSimpleModule
     ]
 
-testFmtWithBuiltinGHC :: IO ()
-testFmtWithBuiltinGHC = expectedOutput @=? actualOutput
+fmtSimpleModule :: IO ()
+fmtSimpleModule = expectedOutput @=? actualOutput
   where
-    config = defaultConfig
     testInput =
       T.unlines
         [ "module Example where"
@@ -32,8 +31,9 @@ testFmtWithBuiltinGHC = expectedOutput @=? actualOutput
         ]
     expectedOutput =
       "module Example where\n\nf :: Bool -> Int\nf True = 1\nf False = 2"
-    ast =
+    source =
       case parseTextToAST testInput defaultParserOpts of
-        Right a -> a
+        Right ast' -> ast'
         Left err -> error $ "test fixture failed to parse: " <> show err
-    actualOutput = fst (execHattier (hattier ast) config initialState)
+    env = Env source defaultConfig
+    actualOutput = fst (execHattier hattier env initialState)


### PR DESCRIPTION
This PR addresses some small issues discussed on Discord:

1. I removed the AST from our `State` because of our new pretty printing approach. I should've put the AST in our `Reader` since we still need it but won't be modifying it. This PR does that.
2. I removed `currentIndent` and `currentColum` from our `Reader` because we can easily shoot ourselves in the foot by forgetting things like decreasing indentation when returning out of a recursive call. We should spawn local `Reader` instances when updating things like current indentation level when recursing.

@nomadalgia please let me know if this PR is too annoying to deal with if this gets merged before https://github.com/hattier-org/hattier/pull/28. Maybe the new `Env` reader is annoying with your new config stuff.